### PR TITLE
Add support ws RPC API and selectable http and ws api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4347,6 +4347,7 @@ dependencies = [
  "serde_json",
  "silius-grpc",
  "silius-primitives",
+ "tokio",
  "tonic",
  "tower",
  "tower-http",

--- a/Makefile
+++ b/Makefile
@@ -2,22 +2,22 @@ build:
 	cargo build --release
 
 run-silius:
-	cargo run --release -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file ${HOME}/.silius/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --beneficiary 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
+	cargo run --release -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file ${HOME}/.silius/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --beneficiary 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --http --ws
 
 run-silius-uopool:
 	cargo run --release --bin silius-uopool -- --eth-client-address http://127.0.0.1:8545 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
 
 run-silius-rpc:
-	cargo run --release --bin silius-rpc
+	cargo run --release --bin silius-rpc --http --ws
 
 run-create-wallet:
 	cargo run --release --bin create-wallet -- --output-path ${HOME}/.silius
 
 run-silius-debug:
-	cargo run --release -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file ${HOME}/.silius/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --beneficiary 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --rpc-api eth,debug,web3
+	cargo run --release -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file ${HOME}/.silius/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --beneficiary 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --http --ws --rpc-api eth,debug,web3
 
 run-silius-debug-mode:
-	RUST_LOG=silius=TRACE cargo run --profile debug-fast -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file /home/vid/.silius/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --beneficiary 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --rpc-api eth,debug,web3
+	RUST_LOG=silius=TRACE cargo run --profile debug-fast -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file /home/vid/.silius/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --beneficiary 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --http --ws --rpc-api eth,debug,web3
 
 fetch-thirdparty:
 	git submodule update --init

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Create wallet for bundler:
 cargo run --release --bin create-wallet -- --output-path ${HOME}/.silius --chain-id 5
 ```
 
-Run bundler (with user operation pool and JSON-RPC API): 
+Run bundler (with user operation pool and JSON-RPC API):
 
 ```bash
-cargo run --release -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file ${HOME}/.silius/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --beneficiary 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
+cargo run --release -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file ${HOME}/.silius/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --beneficiary 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --http --ws
 ```
 
 Run only user operation pool:
@@ -48,10 +48,10 @@ Run only user operation pool:
 cargo run --release --bin silius-uopool -- --eth-client-address http://127.0.0.1:8545 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
 ```
 
-Run only JSON-RPC API: 
+Run only JSON-RPC API:
 
 ```bash
-cargo run --release --bin silius-rpc
+cargo run --release --bin silius-rpc --http --ws
 ```
 
 ## Supported networks

--- a/bin/silius/src/cli.rs
+++ b/bin/silius/src/cli.rs
@@ -53,7 +53,7 @@ pub struct RpcServiceOpts {
 
     /// Enables or disables the HTTP RPC.
     ///
-    /// By default, this option is set to true.
+    /// By default, this option is set to false.
     /// - To enable: `--http`.
     /// - To disable: no `--http` flag.
     #[clap(long)]
@@ -61,7 +61,7 @@ pub struct RpcServiceOpts {
 
     /// Enables or disables the WebSocket RPC.
     ///
-    /// By default, this option is set to true.
+    /// By default, this option is set to false.
     /// - To enable: `--ws`
     /// - To disable: no `--ws` flag.
     #[clap(long)]

--- a/bin/silius/src/cli.rs
+++ b/bin/silius/src/cli.rs
@@ -51,10 +51,20 @@ pub struct RpcServiceOpts {
     #[clap(long, value_delimiter=',', default_value = "eth", value_parser = ["eth", "debug", "web3"])]
     pub rpc_api: Vec<String>,
 
-    #[clap(long, action = Set, default_value = "true")]
+    /// Enables or disables the HTTP RPC.
+    ///
+    /// By default, this option is set to true.
+    /// - To enable: `--http`, `--http true`, or no `http` flag.
+    /// - To disable: `--http false`.
+    #[clap(long, action = Set, num_args=0..=1, default_value = "true", default_missing_value = "true")]
     pub http: bool,
 
-    #[clap(long, action = Set, default_value = "true")]
+    /// Enables or disables the WebSocket RPC.
+    ///
+    /// By default, this option is set to true.
+    /// - To enable: `--ws`, `--ws true`, or no `ws` flag.
+    /// - To disable: `--ws false`.
+    #[clap(long, action = Set, num_args=0..=1, default_value = "true", default_missing_value = "true")]
     pub ws: bool,
 
     #[clap(long, value_delimiter = ',', default_value = "*")]
@@ -101,7 +111,7 @@ mod tests {
     }
 
     #[test]
-    fn rpc_service_opts() {
+    fn rpc_service_opts_when_http_is_true_ws_is_false() {
         let args = vec![
             "rpcserviceopts",
             "--rpc-listen-address",
@@ -139,6 +149,35 @@ mod tests {
             "127.0.0.1:1234",
             "--rpc-api",
             "eth,debug,web3",
+            "--cors-domain",
+            "127.0.0.1:4321",
+        ];
+        assert_eq!(
+            RpcServiceOpts {
+                rpc_listen_address: String::from("127.0.0.1:1234"),
+                rpc_api: vec![
+                    String::from("eth"),
+                    String::from("debug"),
+                    String::from("web3")
+                ],
+                http: true,
+                ws: true,
+                cors_domain: vec![String::from("127.0.0.1:4321")],
+            },
+            RpcServiceOpts::try_parse_from(args).unwrap()
+        );
+    }
+
+    #[test]
+    fn rpc_service_opts_when_http_and_ws_flag() {
+        let args = vec![
+            "rpcserviceopts",
+            "--rpc-listen-address",
+            "127.0.0.1:1234",
+            "--rpc-api",
+            "eth,debug,web3",
+            "--http",
+            "--ws",
             "--cors-domain",
             "127.0.0.1:4321",
         ];

--- a/bin/silius/src/cli.rs
+++ b/bin/silius/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::utils::{parse_address, parse_u256, parse_uopool_mode};
-use clap::{ArgAction::Set, Parser};
+use clap::Parser;
 use ethers::types::{Address, U256};
 use silius_primitives::UoPoolMode;
 use std::net::SocketAddr;
@@ -54,17 +54,17 @@ pub struct RpcServiceOpts {
     /// Enables or disables the HTTP RPC.
     ///
     /// By default, this option is set to true.
-    /// - To enable: `--http`, `--http true`, or no `http` flag.
-    /// - To disable: `--http false`.
-    #[clap(long, action = Set, num_args=0..=1, default_value = "true", default_missing_value = "true")]
+    /// - To enable: `--http`.
+    /// - To disable: no `--http` flag.
+    #[clap(long)]
     pub http: bool,
 
     /// Enables or disables the WebSocket RPC.
     ///
     /// By default, this option is set to true.
-    /// - To enable: `--ws`, `--ws true`, or no `ws` flag.
-    /// - To disable: `--ws false`.
-    #[clap(long, action = Set, num_args=0..=1, default_value = "true", default_missing_value = "true")]
+    /// - To enable: `--ws`
+    /// - To disable: no `--ws` flag.
+    #[clap(long)]
     pub ws: bool,
 
     #[clap(long, value_delimiter = ',', default_value = "*")]
@@ -119,9 +119,6 @@ mod tests {
             "--rpc-api",
             "eth,debug,web3",
             "--http",
-            "true",
-            "--ws",
-            "false",
             "--cors-domain",
             "127.0.0.1:4321",
         ];
@@ -135,6 +132,34 @@ mod tests {
                 ],
                 http: true,
                 ws: false,
+                cors_domain: vec![String::from("127.0.0.1:4321")],
+            },
+            RpcServiceOpts::try_parse_from(args).unwrap()
+        );
+    }
+
+    #[test]
+    fn rpc_service_opts_when_http_is_false_ws_is_true() {
+        let args = vec![
+            "rpcserviceopts",
+            "--rpc-listen-address",
+            "127.0.0.1:1234",
+            "--rpc-api",
+            "eth,debug,web3",
+            "--ws",
+            "--cors-domain",
+            "127.0.0.1:4321",
+        ];
+        assert_eq!(
+            RpcServiceOpts {
+                rpc_listen_address: String::from("127.0.0.1:1234"),
+                rpc_api: vec![
+                    String::from("eth"),
+                    String::from("debug"),
+                    String::from("web3")
+                ],
+                http: false,
+                ws: true,
                 cors_domain: vec![String::from("127.0.0.1:4321")],
             },
             RpcServiceOpts::try_parse_from(args).unwrap()
@@ -160,8 +185,8 @@ mod tests {
                     String::from("debug"),
                     String::from("web3")
                 ],
-                http: true,
-                ws: true,
+                http: false,
+                ws: false,
                 cors_domain: vec![String::from("127.0.0.1:4321")],
             },
             RpcServiceOpts::try_parse_from(args).unwrap()

--- a/bin/silius/src/cli.rs
+++ b/bin/silius/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::utils::{parse_address, parse_u256, parse_uopool_mode};
-use clap::Parser;
+use clap::{ArgAction::Set, Parser};
 use ethers::types::{Address, U256};
 use silius_primitives::UoPoolMode;
 use std::net::SocketAddr;
@@ -51,6 +51,12 @@ pub struct RpcServiceOpts {
     #[clap(long, value_delimiter=',', default_value = "eth", value_parser = ["eth", "debug", "web3"])]
     pub rpc_api: Vec<String>,
 
+    #[clap(long, action = Set, default_value = "true")]
+    pub http: bool,
+
+    #[clap(long, action = Set, default_value = "true")]
+    pub ws: bool,
+
     #[clap(long, value_delimiter = ',', default_value = "*")]
     pub cors_domain: Vec<String>,
 }
@@ -91,6 +97,37 @@ mod tests {
                 bundle_interval: 10,
             },
             BundlerServiceOpts::try_parse_from(args).unwrap()
+        );
+    }
+
+    #[test]
+    fn rpc_service_opts() {
+        let args = vec![
+            "rpcserviceopts",
+            "--rpc-listen-address",
+            "127.0.0.1:1234",
+            "--rpc-api",
+            "eth,debug,web3",
+            "--http",
+            "true",
+            "--ws",
+            "false",
+            "--cors-domain",
+            "127.0.0.1:4321",
+        ];
+        assert_eq!(
+            RpcServiceOpts {
+                rpc_listen_address: String::from("127.0.0.1:1234"),
+                rpc_api: vec![
+                    String::from("eth"),
+                    String::from("debug"),
+                    String::from("web3")
+                ],
+                http: true,
+                ws: false,
+                cors_domain: vec![String::from("127.0.0.1:4321")],
+            },
+            RpcServiceOpts::try_parse_from(args).unwrap()
         );
     }
 }

--- a/bin/silius/src/cli.rs
+++ b/bin/silius/src/cli.rs
@@ -111,6 +111,35 @@ mod tests {
     }
 
     #[test]
+    fn rpc_service_opts_when_http_and_ws_flag() {
+        let args = vec![
+            "rpcserviceopts",
+            "--rpc-listen-address",
+            "127.0.0.1:1234",
+            "--rpc-api",
+            "eth,debug,web3",
+            "--http",
+            "--ws",
+            "--cors-domain",
+            "127.0.0.1:4321",
+        ];
+        assert_eq!(
+            RpcServiceOpts {
+                rpc_listen_address: String::from("127.0.0.1:1234"),
+                rpc_api: vec![
+                    String::from("eth"),
+                    String::from("debug"),
+                    String::from("web3")
+                ],
+                http: true,
+                ws: true,
+                cors_domain: vec![String::from("127.0.0.1:4321")],
+            },
+            RpcServiceOpts::try_parse_from(args).unwrap()
+        );
+    }
+
+    #[test]
     fn rpc_service_opts_when_http_is_true_ws_is_false() {
         let args = vec![
             "rpcserviceopts",
@@ -187,35 +216,6 @@ mod tests {
                 ],
                 http: false,
                 ws: false,
-                cors_domain: vec![String::from("127.0.0.1:4321")],
-            },
-            RpcServiceOpts::try_parse_from(args).unwrap()
-        );
-    }
-
-    #[test]
-    fn rpc_service_opts_when_http_and_ws_flag() {
-        let args = vec![
-            "rpcserviceopts",
-            "--rpc-listen-address",
-            "127.0.0.1:1234",
-            "--rpc-api",
-            "eth,debug,web3",
-            "--http",
-            "--ws",
-            "--cors-domain",
-            "127.0.0.1:4321",
-        ];
-        assert_eq!(
-            RpcServiceOpts {
-                rpc_listen_address: String::from("127.0.0.1:1234"),
-                rpc_api: vec![
-                    String::from("eth"),
-                    String::from("debug"),
-                    String::from("web3")
-                ],
-                http: true,
-                ws: true,
                 cors_domain: vec![String::from("127.0.0.1:4321")],
             },
             RpcServiceOpts::try_parse_from(args).unwrap()

--- a/bin/silius/src/cli.rs
+++ b/bin/silius/src/cli.rs
@@ -130,4 +130,31 @@ mod tests {
             RpcServiceOpts::try_parse_from(args).unwrap()
         );
     }
+
+    #[test]
+    fn rpc_service_opts_when_no_http_and_ws_flag() {
+        let args = vec![
+            "rpcserviceopts",
+            "--rpc-listen-address",
+            "127.0.0.1:1234",
+            "--rpc-api",
+            "eth,debug,web3",
+            "--cors-domain",
+            "127.0.0.1:4321",
+        ];
+        assert_eq!(
+            RpcServiceOpts {
+                rpc_listen_address: String::from("127.0.0.1:1234"),
+                rpc_api: vec![
+                    String::from("eth"),
+                    String::from("debug"),
+                    String::from("web3")
+                ],
+                http: true,
+                ws: true,
+                cors_domain: vec![String::from("127.0.0.1:4321")],
+            },
+            RpcServiceOpts::try_parse_from(args).unwrap()
+        );
+    }
 }

--- a/bin/silius/src/cli.rs
+++ b/bin/silius/src/cli.rs
@@ -71,6 +71,16 @@ pub struct RpcServiceOpts {
     pub cors_domain: Vec<String>,
 }
 
+impl RpcServiceOpts {
+    /// Checks if either HTTP or WebSocket RPC is enabled.
+    ///
+    /// # Returns
+    /// * `bool` - Returns `true` if either HTTP or WebSocket RPC is enabled, otherwise `false`.
+    pub fn is_enabled(&self) -> bool {
+        self.http || self.ws
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -219,6 +229,82 @@ mod tests {
                 cors_domain: vec![String::from("127.0.0.1:4321")],
             },
             RpcServiceOpts::try_parse_from(args).unwrap()
+        );
+    }
+
+    #[test]
+    fn is_enabled_return_true_when_only_http() {
+        assert_eq!(
+            RpcServiceOpts {
+                rpc_listen_address: String::from("127.0.0.1:1234"),
+                rpc_api: vec![
+                    String::from("eth"),
+                    String::from("debug"),
+                    String::from("web3")
+                ],
+                http: true,
+                ws: false,
+                cors_domain: vec![String::from("127.0.0.1:4321")],
+            }
+            .is_enabled(),
+            true
+        );
+    }
+
+    #[test]
+    fn is_enabled_return_true_when_only_ws() {
+        assert_eq!(
+            RpcServiceOpts {
+                rpc_listen_address: String::from("127.0.0.1:1234"),
+                rpc_api: vec![
+                    String::from("eth"),
+                    String::from("debug"),
+                    String::from("web3")
+                ],
+                http: false,
+                ws: true,
+                cors_domain: vec![String::from("127.0.0.1:4321")],
+            }
+            .is_enabled(),
+            true
+        );
+    }
+
+    #[test]
+    fn is_enabled_return_true_when_http_and_ws_are_true() {
+        assert_eq!(
+            RpcServiceOpts {
+                rpc_listen_address: String::from("127.0.0.1:1234"),
+                rpc_api: vec![
+                    String::from("eth"),
+                    String::from("debug"),
+                    String::from("web3")
+                ],
+                http: true,
+                ws: true,
+                cors_domain: vec![String::from("127.0.0.1:4321")],
+            }
+            .is_enabled(),
+            true
+        );
+    }
+
+    #[test]
+    fn is_enabled_return_false_when_http_and_ws_are_false() {
+        assert_eq!(
+            RpcServiceOpts {
+                rpc_listen_address: String::from("127.0.0.1:1234"),
+                rpc_api: vec![
+                    String::from("eth"),
+                    String::from("debug"),
+                    String::from("web3")
+                ],
+                http: false,
+                ws: false,
+                cors_domain: vec![String::from("127.0.0.1:4321")],
+            }
+            .is_enabled(),
+            false
         );
     }
 }

--- a/bin/silius/src/silius-rpc.rs
+++ b/bin/silius/src/silius-rpc.rs
@@ -41,9 +41,13 @@ async fn main() -> Result<()> {
 
     let api: HashSet<String> = HashSet::from_iter(opt.rpc_opts.rpc_api.iter().cloned());
 
-    let mut server = JsonRpcServer::new(opt.rpc_opts.rpc_listen_address.clone())
-        .with_proxy(opt.eth_client_address)
-        .with_cors(opt.rpc_opts.cors_domain);
+    let mut server = JsonRpcServer::new(
+        opt.rpc_opts.rpc_listen_address.clone(),
+        opt.rpc_opts.http,
+        opt.rpc_opts.ws,
+    )
+    .with_proxy(opt.eth_client_address)
+    .with_cors(opt.rpc_opts.cors_domain);
 
     if api.contains("web3") {
         server.add_method(Web3ApiServerImpl {}.into_rpc())?;
@@ -75,8 +79,8 @@ async fn main() -> Result<()> {
 
     let _handle = server.start().await?;
     info!(
-        "Started bundler JSON-RPC server at {:}",
-        opt.rpc_opts.rpc_listen_address
+        "Started bundler JSON-RPC server at {:} with http: {:?} ws: {:?}",
+        opt.rpc_opts.rpc_listen_address, opt.rpc_opts.http, opt.rpc_opts.ws
     );
 
     pending::<Result<()>>().await

--- a/bin/silius/src/silius-rpc.rs
+++ b/bin/silius/src/silius-rpc.rs
@@ -35,6 +35,10 @@ pub struct Opt {
 async fn main() -> Result<()> {
     let opt: Opt = Opt::parse();
 
+    if !opt.rpc_opts.is_enabled() {
+        return Err(anyhow::anyhow!("No RPC protocol is enabled"));
+    }
+
     tracing_subscriber::fmt::init();
 
     info!("Starting bundler JSON-RPC server...");

--- a/bin/silius/src/silius.rs
+++ b/bin/silius/src/silius.rs
@@ -41,9 +41,6 @@ pub struct Opt {
     #[clap(long, default_value="3000000", value_parser=parse_u256)]
     pub max_verification_gas: U256,
 
-    #[clap(long)]
-    pub no_rpc: bool,
-
     #[clap(flatten)]
     pub rpc_opts: RpcServiceOpts,
 
@@ -146,7 +143,8 @@ fn main() -> Result<()> {
                     opt.bundler_opts.bundler_grpc_listen_address
                 );
 
-                if !opt.no_rpc {
+                if opt.rpc_opts.is_enabled() {
+
                     info!("Starting bundler JSON-RPC server...");
                     tokio::spawn({
                         async move {

--- a/bin/silius/src/silius.rs
+++ b/bin/silius/src/silius.rs
@@ -153,7 +153,8 @@ fn main() -> Result<()> {
                             let api: HashSet<String> =
                                 HashSet::from_iter(opt.rpc_opts.rpc_api.iter().cloned());
 
-                            let mut server = JsonRpcServer::new(opt.rpc_opts.rpc_listen_address.clone()).with_proxy(opt.eth_client_address)
+                            let mut server = JsonRpcServer::new(opt.rpc_opts.rpc_listen_address.clone(), opt.rpc_opts.http, opt.rpc_opts.ws)
+                            .with_proxy(opt.eth_client_address)
                             .with_cors(opt.rpc_opts.cors_domain);
 
                             if api.contains("web3") {
@@ -186,8 +187,10 @@ fn main() -> Result<()> {
 
                             let _handle = server.start().await?;
                             info!(
-                                "Started bundler JSON-RPC server at {:}",
-                                opt.rpc_opts.rpc_listen_address
+                                "Started bundler JSON-RPC server at {:} with http: {:?} ws: {:?}",
+                                opt.rpc_opts.rpc_listen_address,
+                                opt.rpc_opts.http,
+                                opt.rpc_opts.ws
                             );
 
                             pending::<Result<()>>().await

--- a/bundler-spec-test/launcher.sh
+++ b/bundler-spec-test/launcher.sh
@@ -1,6 +1,6 @@
-#!/bin/bash 
+#!/bin/bash
 # Launcher script for the Silius.
-set -x 
+set -x
 pushd `dirname \`realpath $0\``
 case $1 in
 
@@ -16,6 +16,8 @@ case $1 in
         --mnemonic-file keys/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 \
         --beneficiary 0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990 \
         --entry-points 0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789 \
+        --http \
+        --ws \
         --rpc-api eth,debug,web3 & echo $! > bundler.pid
     popd
 	cd @account-abstraction && yarn deploy --network localhost

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -25,3 +25,6 @@ silius-primitives = { path = "../primitives" }
 tonic = { version = "0.8", default-features = false, features = ["transport"] }
 tower = { version = "0.4.13" }
 tower-http = { version = "0.4.1", features = ["cors"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -28,9 +28,9 @@ enum JsonRpcProtocolType {
     /// Both HTTP and WS.
     Both,
     /// Only HTTP.
-    OnlyHttp,
+    Http,
     /// Only WS.
-    OnlyWs,
+    Ws,
 }
 
 impl JsonRpcServer {
@@ -133,8 +133,8 @@ impl JsonRpcServer {
         let protocol_type = self.protocol_type()?;
         match protocol_type {
             JsonRpcProtocolType::Both => Ok(ServerBuilder::new()),
-            JsonRpcProtocolType::OnlyHttp => Ok(ServerBuilder::new().http_only()),
-            JsonRpcProtocolType::OnlyWs => Ok(ServerBuilder::new().ws_only()),
+            JsonRpcProtocolType::Http => Ok(ServerBuilder::new().http_only()),
+            JsonRpcProtocolType::Ws => Ok(ServerBuilder::new().ws_only()),
         }
     }
 
@@ -145,8 +145,8 @@ impl JsonRpcServer {
     fn protocol_type(&self) -> anyhow::Result<JsonRpcProtocolType> {
         match (self.http, self.ws) {
             (true, true) => Ok(JsonRpcProtocolType::Both),
-            (true, false) => Ok(JsonRpcProtocolType::OnlyHttp),
-            (false, true) => Ok(JsonRpcProtocolType::OnlyWs),
+            (true, false) => Ok(JsonRpcProtocolType::Http),
+            (false, true) => Ok(JsonRpcProtocolType::Ws),
             (false, false) => Err(anyhow::anyhow!("No protocol type selected")),
         }
     }

--- a/crates/rpc/tests/common.rs
+++ b/crates/rpc/tests/common.rs
@@ -10,23 +10,28 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::atomic::{AtomicU16, Ordering};
 
 static PORT: AtomicU16 = AtomicU16::new(8000);
+/// test_address returns a address on localhost with a increasing port number.
+/// This is to prevent multiple tests from using the same port.
+///
+/// # Returns
+/// * `String` - A localhost address with a increasing port number.
 pub fn test_address() -> String {
     let port = PORT.fetch_add(1, Ordering::SeqCst);
     SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)).to_string()
 }
 
 #[rpc(client, server, namespace = "eth")]
-pub trait DummyApi {
+pub trait DummyEthApi {
     #[method(name = "chainId")]
     async fn chain_id(&self) -> RpcResult<U64>;
 }
 
-pub struct DummyApiServerImpl {
+pub struct DummyEthApiServerImpl {
     pub chain_id: U64,
 }
 
 #[async_trait]
-impl DummyApiServer for DummyApiServerImpl {
+impl DummyEthApiServer for DummyEthApiServerImpl {
     async fn chain_id(&self) -> RpcResult<U64> {
         let chain_id = self.chain_id;
         return Ok(chain_id);

--- a/crates/rpc/tests/common.rs
+++ b/crates/rpc/tests/common.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+use ethers::types::U64;
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
+use jsonrpsee::{
+    core::{Error as RpcError, RpcResult},
+    proc_macros::rpc,
+};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::sync::atomic::{AtomicU16, Ordering};
+
+static PORT: AtomicU16 = AtomicU16::new(8000);
+pub fn test_address() -> String {
+    let port = PORT.fetch_add(1, Ordering::SeqCst);
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)).to_string()
+}
+
+#[rpc(client, server, namespace = "eth")]
+pub trait DummyApi {
+    #[method(name = "chainId")]
+    async fn chain_id(&self) -> RpcResult<U64>;
+}
+
+pub struct DummyApiServerImpl {
+    pub chain_id: U64,
+}
+
+#[async_trait]
+impl DummyApiServer for DummyApiServerImpl {
+    async fn chain_id(&self) -> RpcResult<U64> {
+        let chain_id = self.chain_id;
+        return Ok(chain_id);
+    }
+}
+
+pub fn build_http_client(address: String) -> Result<HttpClient, RpcError> {
+    HttpClientBuilder::default().build(format!("http://{}", address))
+}
+
+pub async fn build_ws_client(address: String) -> Result<WsClient, RpcError> {
+    WsClientBuilder::default()
+        .build(format!("ws://{}", address))
+        .await
+}

--- a/crates/rpc/tests/rpc.rs
+++ b/crates/rpc/tests/rpc.rs
@@ -1,0 +1,85 @@
+mod common;
+
+use ethers::types::U64;
+use silius_rpc::JsonRpcServer;
+use tokio;
+use common::{
+    build_http_client, build_ws_client, test_address, DummyApiClient, DummyApiServer,
+    DummyApiServerImpl,
+};
+
+#[tokio::test]
+async fn test_only_http_rpc_server() {
+    let address = test_address();
+    let http_enabled = true;
+    let ws_disabled = false;
+    let mut server = JsonRpcServer::new(address.clone(), http_enabled, ws_disabled);
+
+    let chain_id: U64 = U64::from(0x7a69);
+    server
+        .add_method(DummyApiServerImpl { chain_id }.into_rpc())
+        .unwrap();
+
+    let handle = server.start().await.unwrap();
+    tokio::spawn(handle.stopped());
+
+    // http client return success response
+    let http_client = build_http_client(address.clone()).unwrap();
+    let http_response = DummyApiClient::chain_id(&http_client).await.unwrap();
+    assert_eq!(http_response, chain_id);
+
+    // ws client cannot connect to http server
+    assert!(build_ws_client(address.clone()).await.is_err());
+}
+
+#[tokio::test]
+async fn test_only_ws_rpc_server() {
+    let address = test_address();
+    let http_disabled = false;
+    let ws_enabled = true;
+    let mut server = JsonRpcServer::new(address.clone(), http_disabled, ws_enabled);
+
+    let chain_id: U64 = U64::from(0x7a69);
+    server
+        .add_method(DummyApiServerImpl { chain_id }.into_rpc())
+        .unwrap();
+
+    let handle = server.start().await.unwrap();
+    tokio::spawn(handle.stopped());
+
+    // http client return error response
+    let http_client = build_http_client(address.clone()).unwrap();
+    let http_response = DummyApiClient::chain_id(&http_client).await;
+    assert!(http_response.is_err());
+
+    // ws client return success response
+    let ws_client = build_ws_client(address.clone()).await.unwrap();
+    let ws_response = DummyApiClient::chain_id(&ws_client).await.unwrap();
+    assert_eq!(ws_response, chain_id);
+}
+
+#[tokio::test]
+async fn test_http_and_ws_rpc_server() {
+    let address = test_address();
+    let http_enabled = true;
+    let ws_enabled = true;
+    let mut server = JsonRpcServer::new(address.clone(), http_enabled, ws_enabled);
+
+    let chain_id: U64 = U64::from(0x7a69);
+    server
+        .add_method(DummyApiServerImpl { chain_id }.into_rpc())
+        .unwrap();
+
+    let handle = server.start().await.unwrap();
+    tokio::spawn(handle.stopped());
+
+    // http client return success response
+    let http_client = build_http_client(address.clone()).unwrap();
+    let http_response = DummyApiClient::chain_id(&http_client).await.unwrap();
+    assert_eq!(http_response, chain_id);
+
+    // ws client return success response
+    let ws_client = build_ws_client(address.clone()).await.unwrap();
+    let ws_response = DummyApiClient::chain_id(&ws_client).await.unwrap();
+    assert_eq!(ws_response, chain_id);
+}

--- a/crates/rpc/tests/rpc.rs
+++ b/crates/rpc/tests/rpc.rs
@@ -9,7 +9,7 @@ use silius_rpc::JsonRpcServer;
 use tokio;
 
 #[tokio::test]
-async fn test_only_http_rpc_server() {
+async fn only_http_rpc_server() {
     let address = test_address();
     let http_enabled = true;
     let ws_disabled = false;
@@ -33,7 +33,7 @@ async fn test_only_http_rpc_server() {
 }
 
 #[tokio::test]
-async fn test_only_ws_rpc_server() {
+async fn only_ws_rpc_server() {
     let address = test_address();
     let http_disabled = false;
     let ws_enabled = true;
@@ -59,7 +59,7 @@ async fn test_only_ws_rpc_server() {
 }
 
 #[tokio::test]
-async fn test_http_and_ws_rpc_server() {
+async fn http_and_ws_rpc_server() {
     let address = test_address();
     let http_enabled = true;
     let ws_enabled = true;

--- a/crates/rpc/tests/rpc.rs
+++ b/crates/rpc/tests/rpc.rs
@@ -1,12 +1,12 @@
 mod common;
 
+use common::{
+    build_http_client, build_ws_client, test_address, DummyEthApiClient, DummyEthApiServer,
+    DummyEthApiServerImpl,
+};
 use ethers::types::U64;
 use silius_rpc::JsonRpcServer;
 use tokio;
-use common::{
-    build_http_client, build_ws_client, test_address, DummyApiClient, DummyApiServer,
-    DummyApiServerImpl,
-};
 
 #[tokio::test]
 async fn test_only_http_rpc_server() {
@@ -17,7 +17,7 @@ async fn test_only_http_rpc_server() {
 
     let chain_id: U64 = U64::from(0x7a69);
     server
-        .add_method(DummyApiServerImpl { chain_id }.into_rpc())
+        .add_method(DummyEthApiServerImpl { chain_id }.into_rpc())
         .unwrap();
 
     let handle = server.start().await.unwrap();
@@ -25,7 +25,7 @@ async fn test_only_http_rpc_server() {
 
     // http client return success response
     let http_client = build_http_client(address.clone()).unwrap();
-    let http_response = DummyApiClient::chain_id(&http_client).await.unwrap();
+    let http_response = DummyEthApiClient::chain_id(&http_client).await.unwrap();
     assert_eq!(http_response, chain_id);
 
     // ws client cannot connect to http server
@@ -41,7 +41,7 @@ async fn test_only_ws_rpc_server() {
 
     let chain_id: U64 = U64::from(0x7a69);
     server
-        .add_method(DummyApiServerImpl { chain_id }.into_rpc())
+        .add_method(DummyEthApiServerImpl { chain_id }.into_rpc())
         .unwrap();
 
     let handle = server.start().await.unwrap();
@@ -49,12 +49,12 @@ async fn test_only_ws_rpc_server() {
 
     // http client return error response
     let http_client = build_http_client(address.clone()).unwrap();
-    let http_response = DummyApiClient::chain_id(&http_client).await;
+    let http_response = DummyEthApiClient::chain_id(&http_client).await;
     assert!(http_response.is_err());
 
     // ws client return success response
     let ws_client = build_ws_client(address.clone()).await.unwrap();
-    let ws_response = DummyApiClient::chain_id(&ws_client).await.unwrap();
+    let ws_response = DummyEthApiClient::chain_id(&ws_client).await.unwrap();
     assert_eq!(ws_response, chain_id);
 }
 
@@ -67,7 +67,7 @@ async fn test_http_and_ws_rpc_server() {
 
     let chain_id: U64 = U64::from(0x7a69);
     server
-        .add_method(DummyApiServerImpl { chain_id }.into_rpc())
+        .add_method(DummyEthApiServerImpl { chain_id }.into_rpc())
         .unwrap();
 
     let handle = server.start().await.unwrap();
@@ -75,11 +75,11 @@ async fn test_http_and_ws_rpc_server() {
 
     // http client return success response
     let http_client = build_http_client(address.clone()).unwrap();
-    let http_response = DummyApiClient::chain_id(&http_client).await.unwrap();
+    let http_response = DummyEthApiClient::chain_id(&http_client).await.unwrap();
     assert_eq!(http_response, chain_id);
 
     // ws client return success response
     let ws_client = build_ws_client(address.clone()).await.unwrap();
-    let ws_response = DummyApiClient::chain_id(&ws_client).await.unwrap();
+    let ws_response = DummyEthApiClient::chain_id(&ws_client).await.unwrap();
     assert_eq!(ws_response, chain_id);
 }


### PR DESCRIPTION
## Changes
- Introduced logic to allow for selectable HTTP and WebSocket endpoints in the json-rpc server.
- Updated CLI arguments to handle `--http` and `--ws` flags for enabling HTTP and WebSocket respectively.
- Modified `JsonRpcServer` instantiation to accept `http` and `ws` boolean flags.

## Related

https://github.com/Vid201/silius/issues/155

## example

```sh
> cargo run --release -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file $HOME/.silius/0xabc.. --beneficiary 0xabc.. --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789

...
2023-08-15T09:11:39.502408Z  INFO silius: Starting bundler JSON-RPC server...
2023-08-15T09:11:39.503029Z  INFO silius: Started bundler JSON-RPC server at http://127.0.0.1:8545 with http: true ws: true


> cargo run --release -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file $HOME/.silius/0xabc.. --beneficiary 0xabc.. --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --http true --ws false

...
2023-08-15T09:11:39.502408Z  INFO silius: Starting bundler JSON-RPC server...
2023-08-15T09:11:39.503029Z  INFO silius: Started bundler JSON-RPC server at http://127.0.0.1:8545 with http: true ws: false


> cargo run --release -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file $HOME/.silius/0xabc.. --beneficiary 0xabc.. --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --http false --ws

...
2023-08-15T09:11:39.502408Z  INFO silius: Starting bundler JSON-RPC server...
2023-08-15T09:11:39.503029Z  INFO silius: Started bundler JSON-RPC server at http://127.0.0.1:8545 with http: false ws: true
```

