### PR TITLE
Fix `calculate_pre_verification_gas` not to happen overflow problem

### DIFF
--- a/crates/uopool/src/utils.rs
+++ b/crates/uopool/src/utils.rs
@@ -317,6 +317,16 @@ pub mod tests {
         );
     }
 
+    #[test]
+    fn div_ceil_divisible_calculation() {
+        assert_eq!(div_ceil(U256::from(10), U256::from(2)), 5.into());
+    }
+
+    #[test]
+    fn div_ceil_no_divisible_calculation() {
+        assert_eq!(div_ceil(U256::from(10), U256::from(3)), 4.into());
+    }
+
     pub fn mempool_test_case<T>(mut mempool: T, not_found_error_message: &str)
     where
         T: Mempool<UserOperations = Vec<UserOperation>> + Debug,

--- a/crates/uopool/src/utils.rs
+++ b/crates/uopool/src/utils.rs
@@ -117,6 +117,20 @@ pub fn calculate_valid_gas(gas_price: U256, gas_incr_perc: U256) -> U256 {
     div_ceil(numerator, denominator)
 }
 
+/// Helper function to calculate the call gas limit of a [UserOperation](UserOperation)
+/// The function is invoked by the [estimate_user_operation_gas](crates::uopool::estimate::estimate_user_operation_gas) method.
+///
+/// # Arguments
+/// `paid` - The paid gas
+/// `pre_op_gas` - The pre-operation gas
+/// `fee_per_gas` - The fee per gas
+///
+/// # Returns
+/// The call gas limit of the [UserOperation](UserOperation)
+pub fn calculate_call_gas_limit(paid: U256, pre_op_gas: U256, fee_per_gas: U256) -> U256 {
+    paid / fee_per_gas - pre_op_gas + Overhead::default().fixed
+}
+
 /// Performs division and rounds up to the nearest integer.
 ///
 /// This function takes a numerator and a denominator of type `U256`,
@@ -141,20 +155,6 @@ fn div_ceil(numerator: U256, denominator: U256) -> U256 {
         .checked_div(denominator)
         .unwrap_or_default()
         .saturating_add(rounding_const)
-}
-
-/// Helper function to calculate the call gas limit of a [UserOperation](UserOperation)
-/// The function is invoked by the [estimate_user_operation_gas](crates::uopool::estimate::estimate_user_operation_gas) method.
-///
-/// # Arguments
-/// `paid` - The paid gas
-/// `pre_op_gas` - The pre-operation gas
-/// `fee_per_gas` - The fee per gas
-///
-/// # Returns
-/// The call gas limit of the [UserOperation](UserOperation)
-pub fn calculate_call_gas_limit(paid: U256, pre_op_gas: U256, fee_per_gas: U256) -> U256 {
-    paid / fee_per_gas - pre_op_gas + Overhead::default().fixed
 }
 
 #[cfg(test)]

--- a/crates/uopool/src/utils.rs
+++ b/crates/uopool/src/utils.rs
@@ -209,7 +209,7 @@ pub mod tests {
         assert_eq!(gas_oh.calculate_pre_verification_gas(&uo), 1549132.into());
     }
 
-    /// This test occurred overflow  when previous `calculate_pre_verification_gas` is used.
+    /// This test occurred overflow when previous `calculate_pre_verification_gas` is used.
     /// previous `calculate_pre_verification_gas` is https://github.com/Vid201/silius/blob/bd79ea0e610adff8d77ba128f53befa8401a4d77/crates/uopool/src/utils.rs#L63-L84
     #[test]
     fn pre_verification_gas_calculation_overflow() {

--- a/crates/uopool/src/utils.rs
+++ b/crates/uopool/src/utils.rs
@@ -172,8 +172,8 @@ pub mod tests {
             pre_verification_gas: U256::max_value(),
             max_fee_per_gas: U256::max_value(),
             max_priority_fee_per_gas: U256::max_value(),
-            paymaster_and_data: Bytes::from(vec![255; 1024]),
-            signature: Bytes::from(vec![255; 1024]), // Large signature
+            paymaster_and_data: Bytes::from(vec![255; 1024]), // Large paymaster_and_data
+            signature: Bytes::from(vec![255; 1024]),          // Large signature
         };
 
         assert_eq!(gas_oh.calculate_pre_verification_gas(&uo), 110020.into());
@@ -202,8 +202,8 @@ pub mod tests {
             pre_verification_gas: U256::max_value(),
             max_fee_per_gas: U256::max_value(),
             max_priority_fee_per_gas: U256::max_value(),
-            paymaster_and_data: Bytes::from(vec![255; 1024]),
-            signature: Bytes::from(vec![255; 1024]), // Large signature
+            paymaster_and_data: Bytes::from(vec![255; 1024]), // Large paymaster_and_data
+            signature: Bytes::from(vec![255; 1024]),          // Large signature
         };
 
         assert_eq!(gas_oh.calculate_pre_verification_gas(&uo), 1549132.into());
@@ -233,8 +233,8 @@ pub mod tests {
             pre_verification_gas: U256::max_value(),
             max_fee_per_gas: U256::max_value(),
             max_priority_fee_per_gas: U256::max_value(),
-            paymaster_and_data: Bytes::from(vec![255; 1024]),
-            signature: Bytes::from(vec![255; 1024]), // Large signature
+            paymaster_and_data: Bytes::from(vec![255; 1024]), // Large paymaster_and_data
+            signature: Bytes::from(vec![255; 1024]),          // Large signature
         };
 
         // This test is mainly to check if the function can handle the overflow scenario without panicking.

--- a/crates/uopool/src/utils.rs
+++ b/crates/uopool/src/utils.rs
@@ -1,4 +1,4 @@
-use ethers::types::{u256_from_f64_saturating, Address, H256, U256};
+use ethers::types::{Address, H256, U256};
 use silius_primitives::{simulation::CodeHash, UserOperation};
 use std::{collections::HashMap, ops::Deref};
 

--- a/crates/uopool/src/utils.rs
+++ b/crates/uopool/src/utils.rs
@@ -143,7 +143,7 @@ pub fn calculate_call_gas_limit(paid: U256, pre_op_gas: U256, fee_per_gas: U256)
 /// # Examples
 ///
 /// ```
-/// # use your_crate::U256; // Replace with the actual import
+/// use ethers::types::U256;
 /// let result = div_ceil(U256::from(10), U256::from(3));
 /// assert_eq!(result, U256::from(4));
 /// ```

--- a/crates/uopool/src/utils.rs
+++ b/crates/uopool/src/utils.rs
@@ -129,7 +129,7 @@ pub fn calculate_valid_gas(gas_price: U256, gas_incr_perc: U256) -> U256 {
 /// let result = div_ceil(U256::from(10), U256::from(3));
 /// assert_eq!(result, U256::from(4));
 /// ```
-pub fn div_ceil(numerator: U256, denominator: U256) -> U256 {
+fn div_ceil(numerator: U256, denominator: U256) -> U256 {
     let rounding_const = U256::from(
         if numerator.checked_rem(denominator).unwrap_or_default() > U256::zero() {
             1

--- a/crates/uopool/src/utils.rs
+++ b/crates/uopool/src/utils.rs
@@ -80,12 +80,6 @@ impl Overhead {
                 .saturating_mul(U256::from(uo_pack.len() + 31)),
             U256::from(32),
         );
-        // let word_cost = self
-        //     .per_user_op_word
-        //     .saturating_mul(U256::from(word_len))
-        //     .checked_div(U256::from(32))
-        //     .unwrap_or_default()
-        //     .saturating_add(rounding_const_word_cost);
 
         // fixed / bundle_size
         // -> fixed / bundle_size + rounding_const

--- a/crates/uopool/src/utils.rs
+++ b/crates/uopool/src/utils.rs
@@ -142,8 +142,9 @@ pub fn calculate_call_gas_limit(paid: U256, pre_op_gas: U256, fee_per_gas: U256)
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// use ethers::types::U256;
+///
 /// let result = div_ceil(U256::from(10), U256::from(3));
 /// assert_eq!(result, U256::from(4));
 /// ```


### PR DESCRIPTION
## Fix `calculate_pre_verification_gas` not to happen overflow problem

### Description

The previous implementation had a potential for overflow. The logic has been modified to prevent this issue.

### Changes

- Removed the use of floating point calculations which might lead to inaccuracies and potential overflows.
- Replaced the previous calculation logic with a more straightforward and safer approach using `saturating_add`, `checked_div`, and other safe arithmetic operations.
- Added tests to ensure the new logic works correctly, especially in scenarios with large user operations and potential overflow situations.

### Relate
`1. type coversion` in https://github.com/Vid201/silius/issues/191
