### PR TITLE
Improve json rpc error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4340,13 +4340,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
+ "regex-automata 0.3.9",
  "regex-syntax 0.7.5",
 ]
 
@@ -4361,9 +4361,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5329,6 +5329,7 @@ dependencies = [
  "ethers-solc 2.0.9",
  "eyre",
  "lazy_static",
+ "regex",
  "serde",
  "serde_json",
  "silius-primitives",

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -14,6 +14,7 @@ AA (ERC-4337) bundler smart contract interfaces
 ethers = { workspace = true }
 eyre = { workspace = true }
 lazy_static = "1.4.0"
+regex = "1.9.6"
 serde = "1"
 serde_json = "1"
 silius-primitives = { path = "../primitives" }

--- a/crates/uopool/src/uopool.rs
+++ b/crates/uopool/src/uopool.rs
@@ -436,13 +436,8 @@ where
         match self.entry_point.simulate_execution(uo.clone()).await {
             Ok(_) => {}
             Err(err) => {
-                return Err(match err {
-                    EntryPointErr::JsonRpcError(err) => SimulationCheckError::Execution {
-                        message: err.message,
-                    },
-                    _ => SimulationCheckError::UnknownError {
-                        message: format!("{err:?}"),
-                    },
+                return Err(SimulationCheckError::Execution {
+                    message: err.to_string(),
                 })
             }
         }
@@ -451,8 +446,11 @@ where
             Ok(res) => res,
             Err(err) => {
                 return Err(match err {
-                    EntryPointErr::JsonRpcError(err) => SimulationCheckError::Execution {
-                        message: err.message,
+                    EntryPointErr::FailedOp(err) => SimulationCheckError::Execution {
+                        message: err.to_string(),
+                    },
+                    EntryPointErr::RevertError(err) => SimulationCheckError::Execution {
+                        message: err.to_string(),
                     },
                     _ => SimulationCheckError::UnknownError {
                         message: format!("{err:?}"),


### PR DESCRIPTION
```
res: "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32603,\"message\":\"Unknown error when simulating validation on entry point. Error message: JsonRpcError(JsonRpcError { code: -32015, message: \\\"VM execution error.\\\", data: Some(String(\\\"Reverted 0x220266b600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001e41413430206f76657220766572696669636174696f6e4761734c696d69740000\\\")) })\"},\"id\":1}"
```

We could see error message like above in estimateGas. The reverted message could be deserialize to Failop with more concrete message. We should provide that to user with better experience.